### PR TITLE
fix: react error on SteamOS 3.7.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "fast-levenshtein": "^3.0.0",
         "hltb-for-deck": "link:",
         "localforage": "^1.10.0",
-        "react": "^18.2.0",
+        "react": "^19.2.0",
         "react-icons": "^4.12.0"
     },
     "lint-staged": {


### PR DESCRIPTION
fixes #23 
Latest SteamOS Stable 3.7.17 gives the following error on loading the plugin:

```
TypeError: Cannot read properties of undefined (reading 'ReactCurrentOwner')
```

This is fixed by updating the version of React from `18.2.0` to `19.2.0`
Attached is a zip file with a build of the fixed plugin.
[hltb-for-deck.zip](https://github.com/user-attachments/files/23624716/hltb-for-deck.zip)


