### PR TITLE
fix: error entering app context menu

### DIFF
--- a/src/patches/LibraryContextMenu.tsx
+++ b/src/patches/LibraryContextMenu.tsx
@@ -5,6 +5,7 @@ import {
     findInReactTree,
     findModuleChild,
     Patch,
+    findInTree,
 } from '@decky/ui';
 
 import { HLTBContextMenuItem } from '../components/HLTBContextMenuItem';
@@ -43,7 +44,17 @@ const contextMenuPatch = (LibraryContextMenu: any) => {
         'render',
         (_: Record<string, unknown>[], component: any) => {
             // Get the current app's ID
-            const appid: number = component._owner.pendingProps.overview.appid;
+            let appid: number;
+            if (component._owner) {
+                appid = component._owner.pendingProps.overview.appid;
+            } else {
+                // Oct 2025 client, SteamOS stable 3.7.17
+                appid = findInTree(
+                    component.props.children,
+                    (x) => x?.app?.appid,
+                    { walkable: ['props', 'children'] }
+                ).app.appid;
+            }
             if (!patches.patchTwo) {
                 patches.patchTwo = afterPatch(
                     component.type.prototype,
@@ -64,16 +75,47 @@ const contextMenuPatch = (LibraryContextMenu: any) => {
                             let updatedAppid = appid;
                             // find the first menu component where there is a different app id than the current one
                             const parentOverview = nextProps.children.find(
-                                (x: any) =>
-                                    x?._owner?.pendingProps?.overview?.appid &&
-                                    x._owner.pendingProps.overview.appid !==
-                                        appid
+                                (x: any) => {
+                                    let componentAppid;
+                                    if (
+                                        x?._owner?.pendingProps?.overview?.appid
+                                    ) {
+                                        componentAppid =
+                                            x._owner.pendingProps.overview
+                                                .appid;
+                                    } else {
+                                        // Oct 2025 client, SteamOS stable 3.7.17 - try to find appid in the tree
+                                        const appData = findInTree(
+                                            x,
+                                            (y) => y?.app?.appid,
+                                            { walkable: ['props', 'children'] }
+                                        );
+                                        componentAppid = appData?.app?.appid;
+                                    }
+                                    return (
+                                        componentAppid &&
+                                        componentAppid !== appid
+                                    );
+                                }
                             );
                             // if found then use that appid
                             if (parentOverview) {
-                                updatedAppid =
-                                    parentOverview._owner.pendingProps.overview
-                                        .appid;
+                                if (
+                                    parentOverview._owner?.pendingProps
+                                        ?.overview?.appid
+                                ) {
+                                    updatedAppid =
+                                        parentOverview._owner.pendingProps
+                                            .overview.appid;
+                                } else {
+                                    // Oct 2025 client, SteamOS stable 3.7.17
+                                    const appData = findInTree(
+                                        parentOverview,
+                                        (x) => x?.app?.appid,
+                                        { walkable: ['props', 'children'] }
+                                    );
+                                    updatedAppid = appData?.app?.appid;
+                                }
                             }
                             addStatsSettingsMenuItem(
                                 nextProps.children,


### PR DESCRIPTION
fixes #23
When entering an app's context menu with the Start button, the following error message will display:
```
TypeError: Cannot read properties of undefined (reading 'pendingProps')
```

This fix is based off of the fix implemented by @doZennn for [decky-steamgriddb](https://github.com/SteamGridDB/decky-steamgriddb/commit/46807c822bdc90814ff6e02a8e50d3645f5d7295) (thank you!)

Zip file with a build of this commit
[hltb-for-deck.zip](https://github.com/user-attachments/files/23649012/hltb-for-deck.zip)
