### PR TITLE
fix: make clearCache async to prevent DataCloneError and race condition

### DIFF
--- a/src/hooks/Cache.ts
+++ b/src/hooks/Cache.ts
@@ -149,8 +149,8 @@ export async function getStatPreferences(): Promise<StatPreferences | null> {
     return preferences;
 }
 
-export const clearCache = () => {
-    const style = getStyle();
-    localforage.clear();
-    updateCache(styleKey, style);
+export const clearCache = async () => {
+    const style = await getStyle();
+    await localforage.clear();
+    await updateCache(styleKey, style);
 };


### PR DESCRIPTION
## Summary

- `clearCache` was synchronous and not awaiting any of its three async operations
- `getStyle()` (async) was not awaited, so its `Promise` object was passed directly to `localforage.setItem()`
- Storing a `Promise` in IndexedDB throws a `DataCloneError` in Chromium-based environments (like the Steam Deck), which breaks all subsequent localforage reads and writes
- This left the plugin permanently unable to load or cache any game data after the user cleared the cache

## Test plan

- [ ] Clear cache in the plugin settings
- [ ] Navigate to a game — HLTB data should load normally
- [ ] Verify style preference is preserved after clearing cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)